### PR TITLE
Update bento_lib requirement to the latest version 2.2.1

### DIFF
--- a/bento_federation_service/package.cfg
+++ b/bento_federation_service/package.cfg
@@ -1,5 +1,5 @@
 [package]
 name = bento_federation_service
-version = 0.8.0
+version = 0.9.0
 authors = David Lougheed
 author_emails = david.lougheed@mail.mcgill.ca

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 appdirs==1.4.4
 attrs==20.3.0
-bento-lib==0.11.0
+bento-lib==2.2.1
 certifi==2020.12.5
 chardet==4.0.0
 codecov==2.1.11


### PR DESCRIPTION
Seems that bento_federation_service also has a dependency on bento_lib search functions.
We introduced #ico in bento_lib 2.1.0, trying now to adapt the front end leads to the error from the federation service. This might fix the error.