### PR TITLE
feat: add data type args to search requests for inner queries

### DIFF
--- a/bento_federation_service/search/dataset_search/handlers/private_dataset.py
+++ b/bento_federation_service/search/dataset_search/handlers/private_dataset.py
@@ -29,7 +29,7 @@ class PrivateDatasetSearchHandler(RequestHandler):
         await self.finish()
 
     async def post(self, dataset_id: str):
-        data_type_queries, join_query, exclude_from_auto_join, fields = get_query_parts(self.request.body)
+        data_type_queries, join_query, exclude_from_auto_join, data_type_args = get_query_parts(self.request.body)
         if not data_type_queries:
             self.set_status(400)
             self.write(bad_request_error("Invalid request format (missing body or data_type_queries)"))
@@ -66,8 +66,8 @@ class PrivateDatasetSearchHandler(RequestHandler):
                 data_type_queries,
                 exclude_from_auto_join,
                 self.include_internal_results,
+                data_type_args,
                 auth_header,
-                fields,
             )
 
             self.write(next(process_dataset_results(

--- a/bento_federation_service/search/dataset_search/query_utils.py
+++ b/bento_federation_service/search/dataset_search/query_utils.py
@@ -1,5 +1,5 @@
 from bento_lib.search.queries import convert_query_to_ast_and_preprocess, Query
-from typing import Dict, Iterable, Optional, Tuple
+from typing import Any, Dict, Iterable, Optional, Tuple
 
 from bento_federation_service.utils import get_request_json
 
@@ -11,10 +11,10 @@ __all__ = [
 
 
 def get_query_parts(request_body: bytes) -> Tuple[Optional[Dict[str, Query]], Optional[Query],
-                                                  Tuple[str, ...], Tuple[str, ...]]:
+                                                  Tuple[str, ...], Dict[str, Dict[str, Any]]]:
     request = get_request_json(request_body)
     if request is None:
-        return None, None, (), ()
+        return None, None, (), {}
 
     # Format: {"data_type": ["#eq", ...]}
     data_type_queries: Optional[Dict[str, Query]] = request.get("data_type_queries")
@@ -25,11 +25,12 @@ def get_query_parts(request_body: bytes) -> Tuple[Optional[Dict[str, Query]], Op
     # Format: list of data types to use as part of a full-join-ish thing instead of an inner-join-ish thing
     exclude_from_auto_join: Tuple[str] = request.get("exclude_from_auto_join", ())
 
-    # Format: list of fields to return in response
-    # e.g. {"fields": ["id", "subject", "biosamples", "diseases"]}
-    fields: Tuple[str] = request.get("fields")
+    # Format: dict of arguments to pass via URL to the nested data type search queries
+    # e.g. a list of fields to return in response (Katsu)
+    #      {"phenopackets": {"fields": ["id", "subject", "biosamples", "diseases"]}}
+    data_type_args: Dict[str, Dict[str, Any]] = request.get("data_type_args", {})
 
-    return data_type_queries, join_query, exclude_from_auto_join, fields
+    return data_type_queries, join_query, exclude_from_auto_join, data_type_args
 
 
 def test_queries(queries: Iterable[Query]) -> None:

--- a/bento_federation_service/utils.py
+++ b/bento_federation_service/utils.py
@@ -22,7 +22,7 @@ RequestBody = Optional[Union[bytes, str]]
 
 async def peer_fetch(client: AsyncHTTPClient, peer: str, path_fragment: str, request_body: RequestBody = None,
                      method: str = "POST", auth_header: Optional[str] = None, extra_headers: Optional[dict] = None,
-                     url_args: Tuple[Tuple[str, str], Tuple[str, Any]] = ()):
+                     url_args: Tuple[Tuple[str, Any], ...] = ()):
     if CHORD_DEBUG:
         print(f"[{SERVICE_NAME}] [DEBUG] {method} to {urljoin(peer, path_fragment)}: {request_body}", flush=True)
 
@@ -32,7 +32,7 @@ async def peer_fetch(client: AsyncHTTPClient, peer: str, path_fragment: str, req
 
     arg_str = ""
     if url_args:
-        print(url_args)
+        print("URL args:", url_args)
         arg_str = "?" + "&".join(f"{k}={url_escape(v)}" for k, v in url_args)
 
     r = await client.fetch(


### PR DESCRIPTION
Idea here:

Outer requests will look something like

```json
{
  "data_type_queries": {
    "phenopacket": true
  },
  "data_type_args": {
    "phenopacket": {
      "fields": ["id", "biosamples"]
    }
}
```

and inner requests where the table is of data type `phenopacket` will be passed here `?query=whatever&fields=id,biosamples`