### PR TITLE
Features/performance reduce queries

### DIFF
--- a/bento_federation_service/package.cfg
+++ b/bento_federation_service/package.cfg
@@ -1,5 +1,5 @@
 [package]
 name = bento_federation_service
-version = 0.12.0
+version = 0.14.0
 authors = David Lougheed
 author_emails = david.lougheed@mail.mcgill.ca

--- a/bento_federation_service/search/dataset_search/dataset_search.py
+++ b/bento_federation_service/search/dataset_search/dataset_search.py
@@ -184,7 +184,7 @@ async def _fetch_table_definition_worker(table_queue: Queue, auth_header: Option
 
             print("url: " + url)
 
-            #TODO: Don't fetch schema except for first time?
+            # TODO: Don't fetch schema except for first time?
             table_ownerships_and_records.append((t, await peer_fetch(
                 client,
                 CHORD_URL,
@@ -241,7 +241,7 @@ async def _table_search_worker(
             # datatype related data without any filtering. For perf. reasons
             # this is unneeded when doing a search
             is_querying_data_type = (table_data_type in data_type_queries
-                and not data_type_queries[table_data_type] is True)
+                                     and not data_type_queries[table_data_type] is True)
 
             # Don't need to fetch results for joining if the join query is None; just check
             # individual tables (which is much faster) using the public discovery endpoint.
@@ -261,10 +261,9 @@ async def _table_search_worker(
             if not is_querying_data_type:
                 continue
 
-
             # Setup up search pre-requisites
             # - defaults:
-            path_fragment=(
+            path_fragment = (
                 f"api/{table_ownership['service_artifact']}{'/private' if private else ''}/tables"
                 f"/{table_record['id']}/search"
             )
@@ -281,19 +280,18 @@ async def _table_search_worker(
             is_using_gohan = USE_GOHAN and table_ownership['service_artifact'] == "gohan"
             if is_using_gohan:
                 # reset path_fragment:
-                path_fragment = (f"api/gohan/variants/get/by/variantId")
+                path_fragment = ("api/gohan/variants/get/by/variantId")
 
                 # reset url_args:
                 # - construct based on search query
                 supplemental_url_args = [["getSampleIdsOnly", "true"]]
                 # - transform custom Query to list of lists to simplify
                 #   the gohan query parameter construction
-                tmpjson=json.dumps({"tmpkey":data_type_queries[table_data_type]})
-                reloaded_converted=json.loads(tmpjson)["tmpkey"]
+                tmpjson = json.dumps({"tmpkey": data_type_queries[table_data_type]})
+                reloaded_converted = json.loads(tmpjson)["tmpkey"]
                 # - generate query parameters from list of query tree objects
                 gohan_query_params = query_utils.construct_gohan_query_params(reloaded_converted, supplemental_url_args)
                 url_args = gohan_query_params
-
 
             # Run the search
             r = await peer_fetch(
@@ -305,7 +303,6 @@ async def _table_search_worker(
                 auth_header=auth_header,  # Required in some cases to not get a 403
                 extra_headers=DATASET_SEARCH_HEADERS,
             )
-
 
             if private:
                 ids = r["results"]
@@ -320,8 +317,8 @@ async def _table_search_worker(
                     #           ]
                     # },...]
                     ids = [call["sample_id"]
-                            for r in ids
-                                for call in r["calls"]]
+                           for r in ids
+                           for call in r["calls"]]
                 # We have a results array to account for
                 results = set(ids)
             else:
@@ -418,11 +415,6 @@ async def run_search_on_dataset(
             join_query = _linked_field_sets_to_join_query(
                 linked_field_sets, set(data_type_queries) - excluded_data_types)
 
-        # Figure out what index combinations we'll need to filter along from the join query,
-        # BEFORE we combine the join query with the data type queries to create the compound
-        # query used to find the actual results.
-        ic_paths_to_filter = _get_array_resolve_paths(join_query) if include_internal_results else []
-
         # Combine the join query with the data type queries, fixing resolves to be consistent
         join_query = _combine_join_and_data_type_queries(join_query, data_type_queries)
 
@@ -476,7 +468,7 @@ async def run_search_on_dataset(
     # Make this code more generic... Maybe, `format` and final `data-type` should
     # be extracted from the request. If these are absent, then fetch results from
     # every service.
-    path_fragment=(
+    path_fragment = (
         f"api/metadata/private/tables/{table_id}/search"
     )
     request_body = json.dumps({

--- a/bento_federation_service/search/dataset_search/dataset_search.py
+++ b/bento_federation_service/search/dataset_search/dataset_search.py
@@ -164,7 +164,7 @@ async def _fetch_table_definition_worker(table_queue: Queue, auth_header: Option
                 url = f"api/gohan/tables/{t['table_id']}"
 
             print("url: " + url)
-            
+
             #TODO: Don't fetch schema except for first time?
             table_ownerships_and_records.append((t, await peer_fetch(
                 client,
@@ -199,7 +199,11 @@ async def _table_search_worker(
         try:
             table_ownership, table_record = table_pair
             table_data_type = table_record["data_type"]
-            is_querying_data_type = table_data_type in data_type_queries
+            # True is a value used instead of the AST strign to return the whole
+            # datatype related data without any filtering. For perf. reasons
+            # this is unneeded when doing a search
+            is_querying_data_type = (table_data_type in data_type_queries
+                and not data_type_queries[table_data_type] is True)
 
             # Don't need to fetch results for joining if the join query is None; just check
             # individual tables (which is much faster) using the public discovery endpoint.

--- a/bento_federation_service/search/dataset_search/dataset_search.py
+++ b/bento_federation_service/search/dataset_search/dataset_search.py
@@ -482,6 +482,12 @@ async def run_search_on_dataset(
         if not include_internal_results:
             return results
 
+        # edge case: no result, no extra query
+        if len(results) == 0:
+            return {
+                "results": []
+            }
+
         request_body = json.dumps({
             "query": [
                         "#in",

--- a/bento_federation_service/search/dataset_search/dataset_search.py
+++ b/bento_federation_service/search/dataset_search/dataset_search.py
@@ -439,8 +439,10 @@ async def run_search_on_dataset(
     # In the next flag, the list comprehension with filtering for lists is used
     # to take care of the case where a data_type is associated with the value
     # `True`, as no query is performed in that case.
-    query_is_phenopacket_only = "phenopacket" in data_type_queries \
-        and len([k for k, val in data_type_queries.items() if isinstance(val, list)]) == 1
+    query_is_phenopacket_only = (
+        "phenopacket" in data_type_queries
+        and isinstance(data_type_queries["phenopacket"], list)
+        and len([k for k, val in data_type_queries.items() if isinstance(val, list)]) == 1)
     if query_is_phenopacket_only:
         request_body = json.dumps({
             "query": data_type_queries["phenopacket"],

--- a/bento_federation_service/search/dataset_search/dataset_search.py
+++ b/bento_federation_service/search/dataset_search/dataset_search.py
@@ -320,7 +320,7 @@ async def _table_search_worker(
                            for r in ids
                            for call in r["calls"]]
                 # We have a results array to account for
-                results = set(ids)
+                results = set(id for id in ids if id is not None)
             else:
                 # Here, the array of 1 True is a dummy value to give a positive result
                 results = {r} if r else set()

--- a/bento_federation_service/search/dataset_search/handlers/datasets.py
+++ b/bento_federation_service/search/dataset_search/handlers/datasets.py
@@ -150,15 +150,13 @@ class DatasetsSearchHandler(RequestHandler):  # TODO: Move to another dedicated 
             print(f"[{SERVICE_NAME} {datetime.now()}] Done fetching individual service search results.", flush=True)
 
             # Aggregate datasets into results list if they satisfy the queries
-            for dataset_id, dataset_results in dataset_objects_dict.items():  # TODO: Worker
-                results.extend(process_dataset_results(
-                    data_type_queries,
-                    dataset_join_queries[dataset_id],
-                    dataset_results,
-                    datasets_dict[dataset_id],
-                    dataset_object_schema,
-                    include_internal_data=False
-                ))
+            for dataset_id, dataset_results in dataset_objects_dict.items():
+                if len(dataset_results) > 0:
+                    d = datasets_dict[dataset_id]
+                    results.append({
+                        **d,
+                        "results": {}
+                    })
 
             self.write({"results": results})
 

--- a/bento_federation_service/search/dataset_search/handlers/datasets.py
+++ b/bento_federation_service/search/dataset_search/handlers/datasets.py
@@ -59,7 +59,7 @@ class DatasetsSearchHandler(RequestHandler):  # TODO: Move to another dedicated 
             try:
                 dataset_id = dataset["identifier"]
 
-                dataset_results, dataset_join_query, _ = await run_search_on_dataset(
+                dataset_results = await run_search_on_dataset(
                     dataset_object_schema,
                     dataset,
                     join_query,
@@ -70,7 +70,6 @@ class DatasetsSearchHandler(RequestHandler):  # TODO: Move to another dedicated 
                 )
 
                 dataset_objects_dict[dataset_id] = dataset_results
-                dataset_join_queries[dataset_id] = dataset_join_query
 
             except HTTPError as e:  # Thrown from run_search_on_dataset
                 # Metadata service error

--- a/bento_federation_service/search/dataset_search/handlers/datasets.py
+++ b/bento_federation_service/search/dataset_search/handlers/datasets.py
@@ -16,7 +16,6 @@ from bento_federation_service.utils import peer_fetch, get_auth_header
 
 from ..constants import DATASET_SEARCH_HEADERS
 from ..dataset_search import run_search_on_dataset
-from ..process_dataset_results import process_dataset_results
 from ..query_utils import get_query_parts, test_queries
 
 

--- a/bento_federation_service/search/dataset_search/handlers/private_dataset.py
+++ b/bento_federation_service/search/dataset_search/handlers/private_dataset.py
@@ -60,7 +60,7 @@ class PrivateDatasetSearchHandler(RequestHandler):
                 "properties": {}
             }
 
-            dataset_results, dataset_join_query, ic_paths_to_filter = await run_search_on_dataset(
+            dataset_results = await run_search_on_dataset(
                 dataset_object_schema,
                 dataset,
                 join_query,
@@ -70,16 +70,10 @@ class PrivateDatasetSearchHandler(RequestHandler):
                 auth_header,
             )
 
-            self.write(next(process_dataset_results(
-                data_type_queries,
-                dataset_join_query,
-                dataset_results,
-                dataset,
-                dataset_object_schema,
-                include_internal_data=True,
-                ic_paths_to_filter=ic_paths_to_filter,
-                always_yield=True,
-            )))
+            self.write({
+                **dataset,
+                **dataset_results
+            })
 
             self.set_header("Content-Type", "application/json")
 

--- a/bento_federation_service/search/dataset_search/handlers/private_dataset.py
+++ b/bento_federation_service/search/dataset_search/handlers/private_dataset.py
@@ -11,7 +11,6 @@ from bento_federation_service.utils import peer_fetch, get_auth_header
 
 from ..constants import DATASET_SEARCH_HEADERS
 from ..dataset_search import run_search_on_dataset
-from ..process_dataset_results import process_dataset_results
 from ..query_utils import get_query_parts, test_queries
 
 

--- a/bento_federation_service/search/dataset_search/handlers/private_dataset.py
+++ b/bento_federation_service/search/dataset_search/handlers/private_dataset.py
@@ -45,6 +45,7 @@ class PrivateDatasetSearchHandler(RequestHandler):
 
             # TODO: Handle dataset 404 properly
 
+            # Collect table_id and linked_field_sets for this dataset
             dataset = await peer_fetch(
                 client,
                 CHORD_URL,

--- a/bento_federation_service/search/dataset_search/query_utils.py
+++ b/bento_federation_service/search/dataset_search/query_utils.py
@@ -37,32 +37,35 @@ def test_queries(queries: Iterable[Query]) -> None:
         # Try compiling each query to make sure it works.
         convert_query_to_ast_and_preprocess(q)
 
+
 def print_tree(tabs, t):
     for i in t:
-        if(isinstance(i, list)):
-            print_tree(tabs+1, i)
+        if isinstance(i, list):
+            print_tree(tabs + 1, i)
         else:
             print(f"{tabs*'   '}{i}")
 
 
 def simple_resolve_tree(t, finalists: list):
-    counter=0
+    counter = 0
     for i in t:
         if isinstance(i, list):
             simple_resolve_tree(i, finalists)
-        if counter == len(t)-1 and (isinstance(i, str) or isinstance(i, int)):
+        if counter == len(t) - 1 and (isinstance(i, str) or isinstance(i, int)):
             finalists.append(str(i))
-        counter+=1
+        counter += 1
     return finalists
 
+
 def pair_up_simple_list(t: List[List[str]]):
-    counter=0
-    pairs=[]
+    counter = 0
+    pairs = []
     for i in t:
         if counter % 2 == 0:
             pairs.append([t[counter], t[counter+1]])
         counter += 1
     return pairs
+
 
 def rename_gohan_compatible(list_pairs):
     for p in list_pairs:
@@ -75,15 +78,16 @@ def rename_gohan_compatible(list_pairs):
         elif p[0] == "genotype_type":
             p[0] = "genotype"
 
+
 def prune_non_gohan_paramters(list_pairs):
     for p in list_pairs:
         if p[0] == "sample_id":
             list_pairs.remove(p)
 
 
-def construct_gohan_query_params(ast: list, supplemental_args: List[List[str]]): 
+def construct_gohan_query_params(ast: list, supplemental_args: List[List[str]]):
     # somehow convert AST to a simple list of lists/strings/ints
-    #converted_ast = [] # temp
+    # converted_ast = [] # temp
 
     # resolve simple key/value pairs
     simple_list = []
@@ -94,7 +98,6 @@ def construct_gohan_query_params(ast: list, supplemental_args: List[List[str]]):
     # prune unnecessary paramers
     prune_non_gohan_paramters(pairs)
     # ensure gohan query param nameing convention matches up
-    rename_gohan_compatible(pairs) 
+    rename_gohan_compatible(pairs)
 
     return tuple(tuple(x) for x in pairs)
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ chardet==4.0.0
 charset-normalizer==2.0.4
 codecov==2.1.12
 coverage==5.5
-debugpy==1.6.2
 distlib==0.3.2
 filelock==3.0.12
 flake8==3.9.2

--- a/run.py
+++ b/run.py
@@ -13,10 +13,13 @@ if __name__ == "__main__":
 
     print(f"[{SERVICE_NAME}] Started")
     if CHORD_DEBUG:
-        import debugpy
-        DEBUGGER_PORT = int(os.environ.get("DEBUGGER_PORT", "5879"))
-        debugpy.listen(("0.0.0.0", DEBUGGER_PORT))
-        print('Debugger Attached')
+        try:
+            import debugpy
+            DEBUGGER_PORT = int(os.environ.get("DEBUGGER_PORT", "5879"))
+            debugpy.listen(("0.0.0.0", DEBUGGER_PORT))
+            print('Debugger Attached')
+        except ImportError:
+            print('Library debugpy not found.')
 
     application.listen(int(os.environ.get("PORT", "5000")))
     tornado.ioloop.IOLoop.instance().start()


### PR DESCRIPTION
This PR changes the way the federation service makes requests to other services in order to reduce the overall payload and response time.
The workflow has been changed to query the different data services to get only the values for the field used to make joins (the value comes from the linked field set, which in effect is the biosample id in the context of Bento). The values are intersected in case of multiple subqueries and are sent once again to katsu to get the phenopackets in a stripped version called "bento_search_results" (basically only the fields necessary to display the list of results in Bento).

Note that this is a breaking change in many aspects:
- in the previous version, the results contained the intersection sect for each datatype queried, not only the phenopackets (in fact since the introduction of Gohan, the variants were not included by default in the response either) 
- the content of the results was more exhaustive as the serialization of the phenopackets was fetching the complete model and its dependencies.

## Tips about the code
`dataset_search.py` contains the main changes in the following functions:
- `_table_search_worker()` which iterates through a queue of "tables" to make queries to them. The query has been changed to return ids that are stored in sets. All the sets are appended to a list which is passed as a reference to this function `dataset_linked_fields_results`
- `run_search_on_dataset()` is the function that calls the former, and makes the intersection between the sets of results. In the context of a private search, it queries Katsu to get the list of corresponding phenopackets in the bento_search_result format. In a public search, it directly returns the set of results (if it is not empty a dataset will be returned, otherwise the response is empty)
`datasets.py` contains the code to run the public search (dataset discovery in Bento). `private_dataset.py` contains the code for the complete results (explore tab in Bento).

## How to test:
- Katsu must be updated to the latest develop branch (after the merge with features/leaner-queries branch)
- Clean the federation service and rebuild the dev version. This is necessary to have the dependencies updated as it relies on the latest version of bento_lib
- Update Bento-Web to the `feature/leaner-queries` branch.

Test searches with the explore tab. Make sure that combinations of subqueries are working correctly, be it with different data services (e.g. experiments with variants). I did some tests with Gohan that seemed conclusive but I am unsure of my current setup.
Also test searches in the dataset discovery mode.
 
